### PR TITLE
Fixed read_timeout set for TaxSvc#request

### DIFF
--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -126,7 +126,7 @@ class TaxSvc
     tries ||= AVALARA_RETRY
     res = RestClient::Request.execute(method: :post,
                                       open_timeout: AVALARA_OPEN_TIMEOUT,
-                                      timeout: AVALARA_READ_TIMEOUT,
+                                      read_timeout: AVALARA_READ_TIMEOUT,
                                       url: service_url + uri,
                                       payload:  JSON.generate(request_hash),
                                       headers: {


### PR DESCRIPTION
`:timeout` options sets timeout both for open and read at the same time. It's better to have it set separately.

docs: https://github.com/rest-client/rest-client#timeouts