### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable'
   s.add_dependency 'rest-client'
   s.add_dependency 'logging'
+  s.add_dependency 'deface', '~> 1.0'
 
   #add gems here for files
   s.add_development_dependency 'dotenv'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here